### PR TITLE
Configure eslint autofix to support our style guide

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   'env': {
     'browser': true,
     'es6': true,
+    'node': true,
   },
 
   'extends': [
@@ -22,11 +23,47 @@ module.exports = {
   ],
 
   'rules': {
-    'indent': ['error', 2, { 'SwitchCase': 1 }],
-    'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
-    'semi': ['error', 'always'],
-    'comma-dangle': ['error', 'always-multiline'],
     'arrow-parens': ['error', 'always'],
     'no-console': 0,
+
+    // Stylistic rules (automatically fixed on commit).
+    'array-bracket-spacing': ['error', 'never'],
+    'brace-style': ['error', '1tbs', { 'allowSingleLine': true }],
+    'comma-dangle': ['error', 'always-multiline'],
+    'comma-spacing': ['error', { 'before': false, 'after': true }],
+    'comma-style': ['error', 'last'],
+    'computed-property-spacing': ['error', 'never'],
+    'eol-last': ['error', 'always'],
+    'func-call-spacing': ['error', 'never'],
+    'indent': ['error', 2, {
+      'SwitchCase': 1,
+      'MemberExpression': 1,
+    }],
+    'jsx-quotes': ['error', 'prefer-double'],
+    'key-spacing': ['error', {
+      'beforeColon': false,
+      'afterColon': true,
+    }],
+    'keyword-spacing': ['error', {
+      'before': true,
+      'after': true,
+    }],
+    'new-parens': 'error',
+    'no-lonely-if': 'error',
+    'no-trailing-spaces': 'error',
+    'no-unneeded-ternary': 'error',
+    'no-whitespace-before-property': 'error',
+    'object-curly-spacing': ['error', 'always'],
+    'operator-assignment': ['error', 'always'],
+    'operator-linebreak': ['error', 'after'],
+    'quote-props': ['error', 'as-needed'],
+    'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
+    'semi-spacing': 'error',
+    'semi': ['error', 'always'],
+    'space-before-blocks': 'error',
+    'space-before-function-paren': ['error', 'never'],
+    'space-in-parens': ['error', 'never'],
+    'space-infix-ops': 'error',
+    'spaced-comment': ['error', 'always', { 'block': { 'balanced': true } }],
   },
 };

--- a/js/App.js
+++ b/js/App.js
@@ -38,13 +38,13 @@ export default class App extends Component {
 
   componentDidMount() {
     BackAndroid.addEventListener('hardwareBackPress', this.onAndroidBack);
-    //Linking.addEventListener('url', this.onDeepLink);
+    // Linking.addEventListener('url', this.onDeepLink);
   }
 
   componentWillUnmount() {
     BackAndroid.removeEventListener('hardwareBackPress', this.onAndroidBack);
-    //Linking.getInitialURL().then((url) => this.onDeepLink({ url }));
-    //Linking.removeEventListener('url', this.onDeepLink);
+    // Linking.getInitialURL().then((url) => this.onDeepLink({ url }));
+    // Linking.removeEventListener('url', this.onDeepLink);
   }
 
   /**
@@ -118,6 +118,6 @@ const styles = StyleSheet.create({
 
   scene: {
     backgroundColor: '#333',
-    paddingTop:  Platform.OS === 'ios' ? 20 : 24,
+    paddingTop: Platform.OS === 'ios' ? 20 : 24,
   },
 });

--- a/js/components/Compass/index.js
+++ b/js/components/Compass/index.js
@@ -1,7 +1,6 @@
-/* global require */
 import React, { Component } from 'react';
 import {
-  /*eslint-disable no-unused-vars*/
+  /* eslint-disable no-unused-vars */
   Image,
   Animated,
   DeviceEventEmitter,
@@ -30,11 +29,11 @@ export default class Compass extends Component {
 
   startHeadingUpdates() {
     ReactNativeHeading.start(this.state.angleFilter)
-    .then((didStart) => {
-      this.setState({
-        headingIsSupported: didStart,
+      .then((didStart) => {
+        this.setState({
+          headingIsSupported: didStart,
+        });
       });
-    });
 
     DeviceEventEmitter.addListener('headingUpdated', (data) => {
       this.startAnimation(data.heading || data);
@@ -46,7 +45,7 @@ export default class Compass extends Component {
     DeviceEventEmitter.removeAllListeners('headingUpdated');
   }
 
-  componentWillMount(){
+  componentWillMount() {
     this.startAnimation(0);
     this.startHeadingUpdates();
   }
@@ -91,17 +90,17 @@ export default class Compass extends Component {
 
   render() {
     return (
-      <Animated.Image 
+      <Animated.Image
         style={[
-          {transform: [{
+          { transform: [{
             rotate: this.state.rotation.interpolate({
-              inputRange:[0, 360],
-              outputRange: ['0 deg', '360 deg']}),
+              inputRange: [0, 360],
+              outputRange: ['0 deg', '360 deg'] }),
           }],
           },
         ]}
         source={require('./assets/arrow.png')}
-    />);  
+    />);
   }
 }
 

--- a/js/components/Header.js
+++ b/js/components/Header.js
@@ -18,7 +18,7 @@ export default class Header extends Component {
   }
 
   render() {
-    const { title='', style, action } = this.props;
+    const { title = '', style, action } = this.props;
 
     return (
       <View style={[styles.header, style]}>

--- a/js/components/MagnetMap/index.js
+++ b/js/components/MagnetMap/index.js
@@ -27,7 +27,7 @@ export default class MagnetMap extends Component {
 
 MagnetMap.propTypes = {
   region: PropTypes.object,
-  children: PropTypes.oneOfType([ PropTypes.object, PropTypes.array ]),
+  children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   style: View.propTypes.style,
 };
 

--- a/js/scenes/Compass.js
+++ b/js/scenes/Compass.js
@@ -22,12 +22,12 @@ export default class Debug extends Component {
   }
 
   componentDidMount() {
-    navigator.geolocation.getCurrentPosition( (position) => {
+    navigator.geolocation.getCurrentPosition((position) => {
       var initialPosition = JSON.stringify(position);
-      this.setState({initialPosition});
+      this.setState({ initialPosition });
     }
       , (error) => console.log(JSON.stringify(error)),
-      {enableHighAccuracy: true, timeout: 20000, maximumAge: 1000}
+      { enableHighAccuracy: true, timeout: 20000, maximumAge: 1000 }
     );
     this.watchID = navigator.geolocation.watchPosition((position) => {
       this.setState({

--- a/js/scenes/Home.js
+++ b/js/scenes/Home.js
@@ -78,7 +78,7 @@ export class Home extends Component {
     return (
       <ActivityIndicator
         animating={true}
-        style={[styles.loading]} size="large" />
+        style={[styles.loading]} size="large"/>
     );
   }
 
@@ -92,7 +92,7 @@ export class Home extends Component {
     );
   }
 
-  renderRow({ value: {id, imageUri } }) {
+  renderRow({ value: { id, imageUri } }) {
     return (
       <TouchableHighlight
         key={id}

--- a/js/scenes/Item.js
+++ b/js/scenes/Item.js
@@ -49,14 +49,13 @@ class Item extends Component {
   renderContent() {
     const { item } = this.props;
     if (!item || item.status === FETCHING) return this.renderContentLoading();
-    const { value: { imageUri }} = item;
+    const { value: { imageUri } } = item;
 
     return (
       <Image
         style={styles.image}
         source={{ uri: imageUri }}
-        resizeMode="cover"
-        ></Image>
+        resizeMode="cover"/>
     );
   }
 

--- a/js/scenes/Map.js
+++ b/js/scenes/Map.js
@@ -1,4 +1,3 @@
-/* global require*/
 import React, { Component, PropTypes } from 'react';
 import { View, StyleSheet } from 'react-native';
 import MagnetMap from '../components/MagnetMap';


### PR DESCRIPTION
Nobody likes coding standards and coding style guide, right?
In this PR, I configured eslint with some stylistic rules that can be fixed automatically.

The choice of the rules mimic our current style guide. So if you like the way the code is currently formatted, you will like these options.

The cool thing is there is nothing special to do as the code is fixed in the [pre-commit hook](https://github.com/mozilla-magnet/journey#how-to-contribute).

I also fixed the current code base and a few minor stylistic issues that slipped through our reviews were fixed.

In the future, we can add more rules (specific to es6 or best practices). This is just an initial implementation.

From now on, let's agree that `.eslintrc.js` is the documentation of our coding style. We don't need to document it anywhere else.